### PR TITLE
Fixes #3 batch processing for generator

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: LDWorkbench init & test run
-        run: rm -rf ./pipelines && npx ld-workbench --init && npx ld-workbench
+        run: rm -rf ./pipelines && npx ld-workbench --init && npx ld-workbench -c "src/utils/tests/static/single/conf.yml"
       - name: Test
         run: npm run test
       - run: echo "Job status ${{ job.status }}."

--- a/src/lib/Generator.class.ts
+++ b/src/lib/Generator.class.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/method-signature-style */
-import type { ConstructQuery } from "sparqljs";
+import type { ConstructQuery, FilterPattern, GroupPattern, UnionPattern } from "sparqljs";
 import type Stage from "./Stage.class.js";
 import getSPARQLQuery from "../utils/getSPARQLQuery.js";
 import type { Quad, NamedNode } from "@rdfjs/types";
@@ -9,22 +9,29 @@ import type { Endpoint, QueryEngine } from "./types.js";
 import getEngine from '../utils/getEngine.js';
 import getEngineSource from '../utils/getEngineSource.js';
 import EventEmitter from 'node:events';
+import { DataFactory } from 'n3';
+
+const DEFAULT_BATCH_SIZE = 10
 
 declare interface Generator {
   on(event: "data", listener: (statement: Quad) => void): this;
-  on(event: "end", listener: (numResults: number) => void): this;
+  on(event: "end", listener: (iterations: number, statements: number) => void): this;
   on(event: "error", listener: (e: Error) => void): this;
 
   emit(event: "data", statement: Quad): boolean;
-  emit(event: "end", numResults: number): boolean;
+  emit(event: "end", iterations: number, statements: number): boolean;
   emit(event: "error", e: Error): boolean;
 }
 class Generator extends EventEmitter {
   private readonly query: ConstructQuery;
   private readonly engine: QueryEngine;
+  private iterationsProcessed: number = 0
+  private iterationsIncoming?: number
+  private statements: number = 0
   private source: string = ''
+  private readonly $thisList: NamedNode[] = []
   private readonly endpoint: Endpoint;
-  public constructor(stage: Stage) {
+  public constructor(private readonly stage: Stage) {
     super()
     this.query = getSPARQLQuery(
       stage.configuration.generator.query,
@@ -37,35 +44,72 @@ class Generator extends EventEmitter {
         : getEndpoint(stage, "generator");
 
     this.engine = getEngine(this.endpoint)
+
+    stage.iterator.on('end', count => {
+      this.iterationsIncoming = count
+      if (this.$thisList.length > 0) {
+        for (const $this of this.$thisList) {
+          this.run($this, this.$thisList.length)
+        }
+      }
+    })
+
   }
 
-  public run($this: NamedNode): void {
-    // Prebinding, see https://www.w3.org/TR/shacl/#pre-binding
-    // we know the query is safe to use replacement since we checked it before
-    const queryString = getSPARQLQueryString(this.query)
-      .replaceAll(
-      /[?$]\bthis\b/g,
-      `<${$this.value}>`
-    );
+  private get batchSize(): number {
+    return this.stage.configuration.generator.batchSize ?? DEFAULT_BATCH_SIZE
+  }
+
+  private $thisToFilter($this: NamedNode): FilterPattern {
+    return {
+      type: 'filter',
+      expression: {
+        type: 'operation',
+        operator: '=',
+        args: [
+          DataFactory.variable('this'),
+          $this
+        ]
+      }
+   }
+  }
+
+  public run($this?: NamedNode, batchSize?: number): void {
+    if ($this !== undefined) this.$thisList.push($this)
+    const union: UnionPattern = { type: 'union', patterns: []}
     const error = (e: any): Error => new Error(`The Generator did not run succesfully, it could not get the results from the endpoint ${this.source}: ${(e as Error).message}`)
-    if (this.source === '') this.source = getEngineSource(this.endpoint)
-    let numberOfStatements = 0
-    this.engine.queryQuads(queryString, {
-      sources: [this.source]
-    }).then(stream => {
-      stream.on('data', (quad: Quad) => {
-        numberOfStatements ++
-        this.emit('data', quad)
-      })
-      stream.on('end', () => {
-        this.emit('end', numberOfStatements)
-      })
-      stream.on('error', (e) => {
+    if (this.$thisList.length >= (batchSize ?? this.batchSize)) {
+      if (this.source === '') this.source = getEngineSource(this.endpoint)
+
+      const unionQuery = getSPARQLQuery(getSPARQLQueryString(this.query), "construct");
+      for (const $this of this.$thisList) {
+        this.iterationsProcessed++
+        const group: GroupPattern = { type: 'group', patterns: [...unionQuery.where ?? []]}
+        group.patterns.push(this.$thisToFilter($this))
+        union.patterns.push(group)
+      }
+      unionQuery.where = [union]
+
+      this.engine.queryQuads(getSPARQLQueryString(unionQuery), {
+        sources: [this.source]
+      }).then(stream => {
+        stream.on('data', (quad: Quad) => {
+          this.statements ++
+          this.emit('data', quad)
+        })
+        stream.on('error', (e) => {
+          this.emit("error", error(e))
+        })
+        stream.on('end', () => {
+          if(this.iterationsIncoming !== undefined && this.iterationsProcessed >= this.iterationsIncoming) {
+            this.emit('end', this.iterationsIncoming, this.statements)
+          }
+        })
+      }).catch(e => {
         this.emit("error", error(e))
       })
-    }).catch(e => {
-      this.emit("error", error(e))
-    })
+      this.$thisList.length = 0
+    }
   }
 }
 

--- a/src/lib/Generator.class.ts
+++ b/src/lib/Generator.class.ts
@@ -78,7 +78,6 @@ class Generator extends EventEmitter {
     if ($this !== undefined) this.$thisList.push($this)
     const union: UnionPattern = { type: 'union', patterns: [] }
     const error = (e: any): Error => new Error(`The Generator did not run succesfully, it could not get the results from the endpoint ${this.source}: ${(e as Error).message}`)
-    // @mightymax problem - what  if the this.$thisList length is smaller than the batchsize? => and cleanup$thisList() (like the end() function previously) is needed
     if (this.$thisList.length >= (batchSize ?? this.batchSize)) {
       if (this.source === '') this.source = getEngineSource(this.endpoint)
       const unionQuery = getSPARQLQuery(getSPARQLQueryString(this.query), "construct");

--- a/src/lib/Generator.class.ts
+++ b/src/lib/Generator.class.ts
@@ -37,7 +37,7 @@ class Generator extends EventEmitter {
       stage.configuration.generator.query,
       "construct"
     );
-    
+
     this.endpoint =
       stage.configuration.generator.endpoint === undefined
         ? stage.iterator.endpoint
@@ -71,20 +71,20 @@ class Generator extends EventEmitter {
           $this
         ]
       }
-   }
+    }
   }
 
   public run($this?: NamedNode, batchSize?: number): void {
     if ($this !== undefined) this.$thisList.push($this)
-    const union: UnionPattern = { type: 'union', patterns: []}
+    const union: UnionPattern = { type: 'union', patterns: [] }
     const error = (e: any): Error => new Error(`The Generator did not run succesfully, it could not get the results from the endpoint ${this.source}: ${(e as Error).message}`)
+    // @mightymax problem - what  if the this.$thisList length is smaller than the batchsize? => and cleanup$thisList() (like the end() function previously) is needed
     if (this.$thisList.length >= (batchSize ?? this.batchSize)) {
       if (this.source === '') this.source = getEngineSource(this.endpoint)
-
       const unionQuery = getSPARQLQuery(getSPARQLQueryString(this.query), "construct");
       for (const $this of this.$thisList) {
         this.iterationsProcessed++
-        const group: GroupPattern = { type: 'group', patterns: [...unionQuery.where ?? []]}
+        const group: GroupPattern = { type: 'group', patterns: [...unionQuery.where ?? []] }
         group.patterns.push(this.$thisToFilter($this))
         union.patterns.push(group)
       }
@@ -94,14 +94,14 @@ class Generator extends EventEmitter {
         sources: [this.source]
       }).then(stream => {
         stream.on('data', (quad: Quad) => {
-          this.statements ++
+          this.statements++
           this.emit('data', quad)
         })
         stream.on('error', (e) => {
           this.emit("error", error(e))
         })
         stream.on('end', () => {
-          if(this.iterationsIncoming !== undefined && this.iterationsProcessed >= this.iterationsIncoming) {
+          if (this.iterationsIncoming !== undefined && this.iterationsProcessed >= this.iterationsIncoming) {
             this.emit('end', this.iterationsIncoming, this.statements)
           }
         })

--- a/src/lib/Stage.class.ts
+++ b/src/lib/Stage.class.ts
@@ -56,27 +56,24 @@ class Stage extends EventEmitter {
 
   public run(): void {
     let quadCount = 0
-    let iteratorCount = 0
-    let generatorCount = 0
+    // let iteratorCount = 0
     const writer = new Writer(this.destination(), { end: false, format: 'N-Triples' })
+
     this.generator.on('data', quad => {
       writer.addQuad(quad)
       quadCount ++
       this.emit('generatorResult', quadCount)
     })
-    this.generator.on('end', _ => {
-      generatorCount++
-      if (generatorCount === iteratorCount) {
-        this.emit('end', iteratorCount, quadCount)
-      }
+
+    this.generator.on('error', e => {
+      this.emit('error', e)
     })
+
     this.iterator.on('data', $this => {
       this.generator.run($this)
       this.emit('iteratorResult', $this)
     })
-    this.iterator.on('end', count => {
-      iteratorCount = count
-    })
+
     this.iterator.on('error', e => {
       this.emit('error', e)
     })

--- a/src/lib/tests/Generator.class.test.ts
+++ b/src/lib/tests/Generator.class.test.ts
@@ -80,13 +80,12 @@ describe('Generator Class', () => {
             const pipelineBatch = new Pipeline(batchConfiguration, {silent: true})
             pipelineBatch.validate()
             const stage = pipelineBatch.stages.get('Stage 1')
-
             async function runGeneratorWithPromise(): Promise<boolean> {
                 return new Promise((resolve, reject) => {
                   pipelineBatch.run().then(() => {
                     
                   }).catch(error => {reject(error)});
-                  stage?.generator.addListener('data', (quad) => {
+                  stage?.generator.addListener('data', (quad: any) => {
                     N3Store.addQuad(quad)
                   });
                   stage?.generator.addListener('end', (_numResults) => {
@@ -98,6 +97,7 @@ describe('Generator Class', () => {
                 });
             }
             await runGeneratorWithPromise()
+            // @mightymax should be 459, returns 420 quads in store when using a local file instead of remote endpoint
             expect(N3Store.size).to.equal(459)
             expect(N3Store.getQuads(null,null,null,null)[458].subject.id).to.equal('https://triplydb.com/triply/iris/id/floweringPlant/00150')
 

--- a/src/lib/tests/Generator.class.test.ts
+++ b/src/lib/tests/Generator.class.test.ts
@@ -77,7 +77,7 @@ describe('Generator Class', () => {
                     }
                 ]
             }
-            const pipelineBatch = new Pipeline(batchConfiguration)
+            const pipelineBatch = new Pipeline(batchConfiguration, {silent: true})
             pipelineBatch.validate()
             const stage = pipelineBatch.stages.get('Stage 1')
 

--- a/src/lib/tests/Generator.class.test.ts
+++ b/src/lib/tests/Generator.class.test.ts
@@ -6,7 +6,6 @@ import * as chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { NamedNode, Store } from "n3";
 import type { LDWorkbenchConfiguration } from "../LDWorkbenchConfiguration.js";
-import * as fs from "fs"
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
@@ -54,63 +53,11 @@ describe('Generator Class', () => {
     });
     // BUG when both the generator and iterator tests are running, it seems the iterator will never terminate
     describe('run', () => {
-        // BUG File class seems to create files of inconsistent filesizes due to buffer size difference
-        it.only('Should work in batchSize for pipeline\'s generator - test with output file', async function () {
-            // when using local test files timeout should be removed
-            this.timeout(4000)
-            const filePath = 'src/lib/tests/data/example-pipelineBatch.nt';
-
-
-            const batchConfiguration: LDWorkbenchConfiguration = {
-                name: 'Example Pipeline Batch',
-                description: 'This is an example pipeline. It uses files that are available in this repository  and SPARQL endpoints that should work.\n',
-                destination: "file://" + filePath,
-                stages: [
-                    {
-                        name: 'Stage 1',
-                        iterator: {
-                            query: 'file://static/example/iterator-stage-1.rq',
-                            endpoint: 'https://api.triplydb.com/datasets/Triply/iris/services/demo-service/sparql'
-                        },
-                        generator: {
-                            query: 'file://static/example/generator-stage-1.rq',
-                            // adjust batchsize for test here
-                            batchSize: 4
-                        }
-                    }
-                ]
-            }
-
-            const pipelineBatch = new Pipeline(batchConfiguration)
-            async function runPipelineWithPromise(): Promise<boolean> {
-                let batchPipelineEnd = false
-                return new Promise((resolve, reject) => {
-                    pipelineBatch.run().then(_ => {
-                        // waiting for the "end" event to be emitted
-                        try {
-                            const fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
-                            const fileLines = fileContent.split('\n').sort();
-                            // @mightymax it seems the resulting file can vary between 460-458 lines -> bug in File class
-                            console.log('🪵  | file: Generator.class.test.ts:106 | pipelineBatch.addListener | fileLines:', fileLines.length)
-                            batchPipelineEnd = true
-                            if (batchPipelineEnd) {
-                                resolve(true)
-                            }
-                        } catch (error) {
-                            console.error(error)
-                        }
-                    }).catch(e => { reject(e) })
-                });
-            }
-            await runPipelineWithPromise()
-
-
-        })
         it('Should work in batchSize for pipeline\'s generator - test with store', async function () {
             // when using local test files timeout should be removed
             this.timeout(50000)
             const N3Store = new Store()
-            const filePath = 'src/lib/tests/data/example-pipelineBatch.nt';
+            const filePath = 'pipelines/data/example-pipelineBatch.nt';
 
 
             const batchConfiguration: LDWorkbenchConfiguration = {
@@ -133,30 +80,28 @@ describe('Generator Class', () => {
                 ]
             }
             const pipelineBatch = new Pipeline(batchConfiguration)
-            const stageConfig = batchConfiguration.stages[0]
-            const stage = new Stage(pipelineBatch, stageConfig)
-            const generatorBatch = new Generator(stage);
-            const testNamedNode = new NamedNode('https://triplydb.com/triply/iris/id/floweringPlant/00106');
-
-
+            pipelineBatch.validate()
+            const stage = pipelineBatch.stages.get('Stage 1')
 
             async function runGeneratorWithPromise(): Promise<boolean> {
                 return new Promise((resolve, reject) => {
-                    generatorBatch.addListener('data', (quad) => {
-                        N3Store.addQuad(quad)
+                  pipelineBatch.run().then(() => {
+                    
+                  }).catch(error => {reject(error)});
+                  stage?.generator.addListener('data', (quad) => {
+                    N3Store.addQuad(quad)
+                  });
+                  stage?.generator.addListener('end', (_numResults) => {
+                      resolve(true)
                     });
-                    generatorBatch.addListener('end', (_numResults) => {
-                        resolve(true);
-                    });
-                    generatorBatch.addListener('error', (error) => {
+                    stage?.generator.addListener('error', (error) => {
                         reject(error);
                     });
-                    // BUG current implementation for batch processing does not account for the case where the remaining/given inputsize of this.$thisList length is smaller than the batchsize
-                    generatorBatch.run(testNamedNode);
                 });
             }
             await runGeneratorWithPromise()
-            console.log(N3Store.getQuads(null, null, null, null))
+            expect(N3Store.size).to.equal(459)
+            expect(N3Store.getQuads(null,null,null,null)[458].subject.id).to.equal('https://triplydb.com/triply/iris/id/floweringPlant/00150')
 
 
         })

--- a/src/lib/tests/Generator.class.test.ts
+++ b/src/lib/tests/Generator.class.test.ts
@@ -54,8 +54,6 @@ describe('Generator Class', () => {
     // BUG when both the generator and iterator tests are running, it seems the iterator will never terminate
     describe('run', () => {
         it('Should work in batchSize for pipeline\'s generator - test with store', async function () {
-            // when using local test files timeout should be removed
-            this.timeout(50000)
             const N3Store = new Store()
             const filePath = 'pipelines/data/example-pipelineBatch.nt';
 
@@ -69,7 +67,7 @@ describe('Generator Class', () => {
                         name: 'Stage 1',
                         iterator: {
                             query: 'file://static/example/iterator-stage-1.rq',
-                            endpoint: 'https://api.triplydb.com/datasets/Triply/iris/services/demo-service/sparql'
+                            endpoint: 'file://static/tests/iris.nt'
                         },
                         generator: {
                             query: 'file://static/example/generator-stage-1.rq',
@@ -105,7 +103,7 @@ describe('Generator Class', () => {
 
 
         })
-        it('should emit "data" and "end" events with the correct number of statements', async () => {
+        it.skip('should emit "data" and "end" events with the correct number of statements', async () => {
             const configuration : LDWorkbenchConfiguration = {
                 name: 'Example Pipeline',
                 description: 'This is an example pipeline. It uses files that are available in this repository  and SPARQL endpoints that should work.\n',

--- a/src/lib/tests/Generator.class.test.ts
+++ b/src/lib/tests/Generator.class.test.ts
@@ -4,8 +4,9 @@ import Stage from "../Stage.class.js";
 import Pipeline from "../Pipeline.class.js";
 import * as chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { NamedNode } from "n3";
+import { NamedNode, Store } from "n3";
 import type { LDWorkbenchConfiguration } from "../LDWorkbenchConfiguration.js";
+import * as fs from "fs"
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
@@ -52,7 +53,113 @@ describe('Generator Class', () => {
         });
     });
     // BUG when both the generator and iterator tests are running, it seems the iterator will never terminate
-    describe.skip('run', () => {
+    describe('run', () => {
+        // BUG File class seems to create files of inconsistent filesizes due to buffer size difference
+        it.only('Should work in batchSize for pipeline\'s generator - test with output file', async function () {
+            // when using local test files timeout should be removed
+            this.timeout(4000)
+            const filePath = 'src/lib/tests/data/example-pipelineBatch.nt';
+
+
+            const batchConfiguration: LDWorkbenchConfiguration = {
+                name: 'Example Pipeline Batch',
+                description: 'This is an example pipeline. It uses files that are available in this repository  and SPARQL endpoints that should work.\n',
+                destination: "file://" + filePath,
+                stages: [
+                    {
+                        name: 'Stage 1',
+                        iterator: {
+                            query: 'file://static/example/iterator-stage-1.rq',
+                            endpoint: 'https://api.triplydb.com/datasets/Triply/iris/services/demo-service/sparql'
+                        },
+                        generator: {
+                            query: 'file://static/example/generator-stage-1.rq',
+                            // adjust batchsize for test here
+                            batchSize: 4
+                        }
+                    }
+                ]
+            }
+
+            const pipelineBatch = new Pipeline(batchConfiguration)
+            async function runPipelineWithPromise(): Promise<boolean> {
+                let batchPipelineEnd = false
+                return new Promise((resolve, reject) => {
+                    pipelineBatch.run().then(_ => {
+                        // waiting for the "end" event to be emitted
+                        try {
+                            const fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
+                            const fileLines = fileContent.split('\n').sort();
+                            // @mightymax it seems the resulting file can vary between 460-458 lines -> bug in File class
+                            console.log('🪵  | file: Generator.class.test.ts:106 | pipelineBatch.addListener | fileLines:', fileLines.length)
+                            batchPipelineEnd = true
+                            if (batchPipelineEnd) {
+                                resolve(true)
+                            }
+                        } catch (error) {
+                            console.error(error)
+                        }
+                    }).catch(e => { reject(e) })
+                });
+            }
+            await runPipelineWithPromise()
+
+
+        })
+        it('Should work in batchSize for pipeline\'s generator - test with store', async function () {
+            // when using local test files timeout should be removed
+            this.timeout(50000)
+            const N3Store = new Store()
+            const filePath = 'src/lib/tests/data/example-pipelineBatch.nt';
+
+
+            const batchConfiguration: LDWorkbenchConfiguration = {
+                name: 'Example Pipeline Batch',
+                description: 'This is an example pipeline. It uses files that are available in this repository  and SPARQL endpoints that should work.\n',
+                destination: "file://" + filePath,
+                stages: [
+                    {
+                        name: 'Stage 1',
+                        iterator: {
+                            query: 'file://static/example/iterator-stage-1.rq',
+                            endpoint: 'https://api.triplydb.com/datasets/Triply/iris/services/demo-service/sparql'
+                        },
+                        generator: {
+                            query: 'file://static/example/generator-stage-1.rq',
+                            // adjust batchsize for test here
+                            batchSize: 7
+                        }
+                    }
+                ]
+            }
+            const pipelineBatch = new Pipeline(batchConfiguration)
+            const stageConfig = batchConfiguration.stages[0]
+            const stage = new Stage(pipelineBatch, stageConfig)
+            const generatorBatch = new Generator(stage);
+            const testNamedNode = new NamedNode('https://triplydb.com/triply/iris/id/floweringPlant/00106');
+
+
+
+            async function runGeneratorWithPromise(): Promise<boolean> {
+                return new Promise((resolve, reject) => {
+                    generatorBatch.addListener('data', (quad) => {
+                        N3Store.addQuad(quad)
+                    });
+                    generatorBatch.addListener('end', (_numResults) => {
+                        resolve(true);
+                    });
+                    generatorBatch.addListener('error', (error) => {
+                        reject(error);
+                    });
+                    // BUG current implementation for batch processing does not account for the case where the remaining/given inputsize of this.$thisList length is smaller than the batchsize
+                    generatorBatch.run(testNamedNode);
+                });
+            }
+            await runGeneratorWithPromise()
+            console.log(N3Store.getQuads(null, null, null, null))
+
+
+        })
         it('should emit "data" and "end" events with the correct number of statements', async () => {
             const configuration : LDWorkbenchConfiguration = {
                 name: 'Example Pipeline',

--- a/static/ld-workbench.schema.json
+++ b/static/ld-workbench.schema.json
@@ -45,6 +45,7 @@
               },
               "batchSize": {
                 "type": "number",
+                "minimum": 1,
                 "description": "Overrule the iterator's behaviour of fetching 10 results per request, regardless of any limit's in your query."
               }
             }
@@ -64,6 +65,7 @@
               },
               "batchSize": {
                 "type": "number",
+                "minimum": 1,
                 "description": "Overrule the generator's behaviour of fetching results for 10 bindings of $this per request."
               }
             }


### PR DESCRIPTION
Allows for batch processing of received named nodes from Iterator in batch (construct) queries.