### PR TITLE
fix: Init

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,8 @@
 .vscode
 .idea
 src/
-static/
+static/ao
+static/figures
+static/tests
 tsconfig.json
 .eslintrc.json

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ stages:
 2. Install LD Workbench:
 
    ```sh
-   npx @netwerk-digitaal-erfgoed/ld-workbench -- --init
+   npx @netwerk-digitaal-erfgoed/ld-workbench --init
    ```
 
    Your workbench is now ready for use.

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -5,13 +5,11 @@ import glob from 'glob'
 
 export default function init(): void {
   const $dirname = path.dirname(fileURLToPath(import.meta.url));
-  if(fs.existsSync('pipelines')) {
-    throw new Error('The --init script found an existing directory "pipelines". Make sure this directory does not exists before running this script.')
+  if(fs.existsSync(path.join('pipelines', 'configurations', 'example'))) {
+    throw new Error('The --init script found an existing directory "' + path.join('pipelines', 'configurations', 'example') + '". Make sure this directory does not exists before running this script.')
   }
-  fs.mkdirSync('pipelines')
-  fs.mkdirSync(path.join('pipelines', 'data'))
-  fs.mkdirSync(path.join('pipelines', 'configurations'))
-  fs.mkdirSync(path.join('pipelines', 'configurations', 'example'))
+  fs.mkdirSync(path.join('pipelines', 'data'), {recursive: true})
+  fs.mkdirSync(path.join('pipelines', 'configurations', 'example'), {recursive: true})
   const filepaths = glob.sync(path.join($dirname, '..', '..', 'static', 'example', '*'))
   for(const filepath of filepaths) {
     fs.copyFileSync(filepath, path.join('pipelines', 'configurations', 'example', path.basename(filepath)))


### PR DESCRIPTION
- the `--` ([double dash](https://www.cyberciti.biz/faq/what-does-double-dash-mean-in-ssh-command)) argument should not be used in the described use-case.
- the init script should only test for specific `pipelines/configuration/example` folder, not for `pipelines`
- if "static" is excluded from the NPM package (like it was in `.npmignore`), the example pipeline can not be installed with `--init`, since it is not present

Fix #48 