### PR TITLE
fix: Number of statements for multiple generators

### DIFF
--- a/src/lib/Stage.class.ts
+++ b/src/lib/Stage.class.ts
@@ -87,19 +87,18 @@ class Stage extends EventEmitter {
       end: false,
       format: 'N-Triples',
     });
-    let quadCount = 0;
 
     const generatorProcessedCounts = new Map<number, number>();
     let quadsGenerated = 0;
 
-    const checkEnd = (iterationsIncoming: number, statements: number): void => {
+    const checkEnd = (iterationsIncoming: number): void => {
       if (
         ![...generatorProcessedCounts].some(
           ([, processed]) => processed < iterationsIncoming
         ) &&
         this.iteratorEnded
       ) {
-        this.emit('end', iterationsIncoming, statements);
+        this.emit('end', iterationsIncoming, quadsGenerated);
       }
     };
 
@@ -109,13 +108,12 @@ class Stage extends EventEmitter {
       generator.on('data', quad => {
         quadsGenerated++;
         writer.addQuad(quad);
-        quadCount++;
-        this.emit('generatorResult', quadCount);
+        this.emit('generatorResult', quadsGenerated);
       });
 
       generator.on('end', (iterationsIncoming, statements, processed) => {
         generatorProcessedCounts.set(index, processed);
-        checkEnd(iterationsIncoming, statements);
+        checkEnd(iterationsIncoming);
       });
 
       generator.on('error', e => {


### PR DESCRIPTION
When multiple generators are configured, the number of statements
reporting was that of only one of those generators, picked randomly
based on which generator ends first. Fix that by reporting the
total number of statements for all generators combined.
