### PR TITLE
fix: Set source type for endpoints

### DIFF
--- a/src/lib/tests/Generator.class.test.ts
+++ b/src/lib/tests/Generator.class.test.ts
@@ -68,7 +68,6 @@ describe('Generator Class', () => {
       expect(generator).to.have.property('query');
       expect(generator).to.have.property('engine');
       expect(generator).to.have.property('endpoint');
-      expect(generator).to.have.property('source');
     });
   });
   describe('run', () => {
@@ -108,8 +107,6 @@ describe('Generator Class', () => {
       };
       // read file after pipeline has finished
       const pipelineParallelGenerators = new Pipeline(config, {silent: true});
-      pipelineParallelGenerators.validate();
-
       await pipelineParallelGenerators.run();
       const file = fs.readFileSync(filePath, {encoding: 'utf-8'});
       const fileLines = file.split('\n').sort();
@@ -148,7 +145,6 @@ describe('Generator Class', () => {
         ],
       };
       const pipelineBatch = new Pipeline(batchConfiguration, {silent: true});
-      pipelineBatch.validate();
       pipelineBatch
         .run()
         .then(() => {

--- a/src/lib/tests/Iterator.class.test.ts
+++ b/src/lib/tests/Iterator.class.test.ts
@@ -65,7 +65,6 @@ describe('Iterator Class', () => {
       expect(iterator).to.have.property('query');
       expect(iterator).to.have.property('endpoint');
       expect(iterator).to.have.property('engine');
-      expect(iterator).to.have.property('source');
       expect(iterator).to.have.property('$offset', 0);
       expect(iterator).to.have.property('totalResults', 0);
     });

--- a/src/lib/tests/Pipeline.class.test.ts
+++ b/src/lib/tests/Pipeline.class.test.ts
@@ -55,7 +55,6 @@ describe('Pipeline Class', () => {
       expect(pipeline).to.be.an.instanceOf(Pipeline);
       expect(pipeline).to.have.property('stages').that.is.a('Map');
       expect(pipeline).to.have.property('dataDir').that.is.a('string');
-      expect(pipeline).to.have.property('$isValidated', false);
       expect(pipeline).to.have.property('stageNames').that.is.an('array');
       expect(pipeline).to.have.property('startTime').that.is.an('number');
       expect(pipeline)
@@ -99,7 +98,6 @@ describe('Pipeline Class', () => {
         ],
       };
       const pipeline = new Pipeline(configuration, {silent: true});
-      pipeline.validate();
 
       const stage1 = pipeline.stages.get('Stage 1')!;
       const stage2 = pipeline.stages.get('Stage 2')!;
@@ -155,10 +153,9 @@ describe('Pipeline Class', () => {
         destination: 'file://pipelines/data/example-pipeline.nt',
         stages: [],
       } as unknown as LDWorkbenchConfiguration;
-      const pipeline = new Pipeline(invalidConfiguration, {silent: true});
       let failed = false;
       try {
-        pipeline.validate();
+        new Pipeline(invalidConfiguration, {silent: true});
       } catch (error) {
         if (error instanceof Error) {
           if (error.message === 'Your pipeline contains no stages.') {
@@ -204,10 +201,9 @@ describe('Pipeline Class', () => {
           },
         ],
       } as unknown as LDWorkbenchConfiguration;
-      const pipeline = new Pipeline(invalidConfiguration, {silent: true});
       let failed = false;
       try {
-        pipeline.validate();
+        new Pipeline(invalidConfiguration, {silent: true});
       } catch (error) {
         if (error instanceof Error) {
           if (
@@ -259,10 +255,9 @@ describe('Pipeline Class', () => {
           },
         ],
       };
-      const pipeline = new Pipeline(configDuplicateStageName, {silent: true});
       let failed = false;
       try {
-        pipeline.validate();
+        new Pipeline(configDuplicateStageName, {silent: true});
       } catch (error) {
         if (error instanceof Error) {
           if (
@@ -315,10 +310,9 @@ describe('Pipeline Class', () => {
           },
         ],
       };
-      const pipeline = new Pipeline(configDuplicateStageName, {silent: true});
       let failed = false;
       try {
-        pipeline.validate();
+        new Pipeline(configDuplicateStageName, {silent: true});
       } catch (error) {
         failed = true;
         if (error instanceof Error) {

--- a/src/lib/tests/PreviousStage.class.test.ts
+++ b/src/lib/tests/PreviousStage.class.test.ts
@@ -43,7 +43,6 @@ describe('PreviousStage Class', () => {
         ],
       };
       const pipeline = new Pipeline(config, {silent: true});
-      pipeline.validate();
       const stage: Stage = new Stage(pipeline, config.stages[1]);
       const stagesSoFar = Array.from(stage.pipeline.stages.keys());
       const previousStage = new PreviousStage(stage, stagesSoFar.pop()!);
@@ -88,7 +87,6 @@ describe('PreviousStage Class', () => {
         ],
       };
       const pipeline = new Pipeline(config, {silent: true});
-      pipeline.validate();
       const stage: Stage = new Stage(pipeline, config.stages[0]);
       const stagesSoFar = Array.from(stage.pipeline.stages.keys());
       const previousStage = new PreviousStage(stage, stagesSoFar.pop()!);
@@ -132,7 +130,6 @@ describe('PreviousStage Class', () => {
         ],
       };
       const pipeline = new Pipeline(config, {silent: true});
-      pipeline.validate();
       const stageTwo: Stage = new Stage(pipeline, config.stages[1]);
       const stagesSoFar = Array.from(stageTwo.pipeline.stages.keys());
       const previousStage = new PreviousStage(stageTwo, stagesSoFar.pop()!); // should be stage one
@@ -178,7 +175,6 @@ describe('PreviousStage Class', () => {
         ],
       };
       const pipeline = new Pipeline(config, {silent: true});
-      pipeline.validate();
       const stage: Stage = new Stage(pipeline, config.stages[1]);
       const stagesSoFar = Array.from(stage.pipeline.stages.keys());
       const previousStage = new PreviousStage(stage, stagesSoFar.pop()!);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,3 +5,4 @@ import {type QueryEngine as QueryEngineFile} from '@comunica/query-sparql-file';
 
 export type Endpoint = File | URL | PreviousStage;
 export type QueryEngine = QueryEngineSparql | QueryEngineFile;
+export type QuerySource = {type?: string; value: string};

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,12 +72,11 @@ async function main(): Promise<void> {
     );
   }
 
-  const pipeline = new Pipeline(configuration, {
-    startFromStageName: cliArgs.stage,
-    silent: cliArgs.silent,
-  });
-
   try {
+    const pipeline = new Pipeline(configuration, {
+      startFromStageName: cliArgs.stage,
+      silent: cliArgs.silent,
+    });
     await pipeline.run();
   } catch (e) {
     error(

--- a/src/utils/getEndpoint.ts
+++ b/src/utils/getEndpoint.ts
@@ -25,8 +25,7 @@ export default function getEndpoint(
     return new File(endpoint);
   } else if (endpoint !== undefined) {
     try {
-      // fix for GraphDB, see https://github.com/comunica/comunica/issues/962
-      return new URL((endpoint as string).replace(/^sparql@/, ''));
+      return new URL(endpoint);
     } catch (e) {
       throw new Error(`"${endpoint as string}" is not a valid URL`);
     }

--- a/src/utils/getEngineSource.ts
+++ b/src/utils/getEngineSource.ts
@@ -1,10 +1,9 @@
 import {isPreviousStage} from './guards.js';
 import {existsSync} from 'fs';
 import path from 'path';
-import type {Endpoint} from '../lib/types.js';
+import type {Endpoint, QuerySource} from '../lib/types.js';
 
-export default function getEngineSource(endpoint: Endpoint): string {
-  let source: string;
+export default function getEngineSource(endpoint: Endpoint): QuerySource {
   if (isPreviousStage(endpoint)) {
     const previousStage = endpoint.load();
     if (!existsSync(previousStage.destinationPath)) {
@@ -12,9 +11,18 @@ export default function getEngineSource(endpoint: Endpoint): string {
         `The result from stage "${previousStage.name}" (${previousStage.destinationPath}) is not available, make sure to run that stage first`
       );
     }
-    source = path.resolve(previousStage.destinationPath);
-  } else {
-    source = endpoint.toString();
+    return {
+      type: 'file',
+      value: path.resolve(previousStage.destinationPath),
+    };
+  } else if (endpoint instanceof URL) {
+    return {
+      type: 'sparql',
+      value: endpoint.toString(),
+    };
   }
-  return source;
+
+  return {
+    value: endpoint.toString(),
+  };
 }


### PR DESCRIPTION
* Remove the need for users to specify `sparql@...`.
* Refactor Pipeline to validate in constructor instead of requiring a
  separate call to `valiate()`. This also allows us to remove the 
  `isValidated` flags.

Fix #44.
