### PR TITLE
feat: Simplify CLI args by removing configDir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ git clone https://github.com/netwerk-digitaal-erfgoed/ld-workbench.git
 cd ld-workbench
 npm i
 npm run compile
-npm run ld-workbench -- --configDir static/example
+npm run ld-workbench -- --config static/example
 ```
 
 The configuration of this project is validated and defined by [JSON Schema](https://json-schema.org). The schema is located in `./static/ld-workbench-schema.json`. To create the types from this schema, run `npm run util:json-schema-to-typescript`. This will regenerate `./src/types/LDWorkbenchConfiguration.d.ts`, do not modify this file by hand.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepare": "husky install",
     "dev": "tsc --watch --preserveWatchOutput",
     "ld-workbench": "node build/main",
-    "ld-workbench:example": "node build/main --configDir static",
+    "ld-workbench:example": "node build/main --config static",
     "util:json-schema-to-typescript": "npx json2ts -i ./static/ld-workbench.schema.json -o src/lib/LDWorkbenchConfiguration.d.ts",
     "semantic-release": "semantic-release",
     "lint": "gts lint",
@@ -21,7 +21,7 @@
     "compile": "tsc",
     "fix": "gts fix",
     "pretest": "npm run compile",
-    "posttest": "npm run lint"
+    "posttest": "npm run fix"
   },
   "repository": {
     "type": "git",

--- a/src/cliArgs.ts
+++ b/src/cliArgs.ts
@@ -8,12 +8,9 @@ program
   .name('ld-workbench')
   .description('CLI tool to transform Linked Data using SPARQL')
   .option(
-    '-c, --config <config.yml>',
-    'Path to a configuration file for your pipeline.'
-  )
-  .option(
-    '--configDir </path/to/yaml/>',
-    'Path to a folder containing your configuration files.'
+    '-c, --config </path/to/configurations/>',
+    'Path to the directory containing your pipeline configuration(s)',
+    'pipelines/'
   )
   .option(
     '-p, --pipeline <name-of-pipeline>',
@@ -23,16 +20,15 @@ program
     '-s, --stage <name-of-stage>',
     'Name of the stage of the pipeline you want to run'
   )
-  .option('--init', 'Initializes a new LDWorkbench project')
+  .option('--init', 'Initialize a new LDWorkbench project')
   .option(
     '--silent',
-    'Disable console output, including the progress indicator.'
+    'Disable console output, including the progress indicator'
   )
   .version(version());
 program.parse();
 export const cliArgs: {
-  config?: string;
-  configDir?: string;
+  config: string;
   pipeline?: string;
   stage?: string;
   silent?: boolean;
@@ -40,7 +36,7 @@ export const cliArgs: {
 } = program.opts();
 
 if (cliArgs.init !== undefined) {
-  if (Object.values(cliArgs).length !== 1) {
+  if (Object.values(cliArgs).length !== 2) {
     error(
       'The --init flag can not be used in conjunction with other CLI arguments.'
     );
@@ -55,27 +51,4 @@ if (cliArgs.init !== undefined) {
   } catch (e) {
     error(e as Error);
   }
-}
-
-if (cliArgs.config !== undefined && cliArgs.configDir !== undefined) {
-  error(
-    'Do not use both the --config and the --configDir options.',
-    1,
-    `${chalk.italic(
-      '--config'
-    )} should be used to process a single pipeline, ${chalk.italic(
-      '--configDir'
-    )} should be used to overwrite the default director where LD Workbench searches configs (${chalk.italic(
-      './pipelines/'
-    )}).`
-  );
-}
-if (cliArgs.config !== undefined && cliArgs.pipeline !== undefined) {
-  error(
-    'Do not use both the --config and the --pipeline options.',
-    1,
-    `Both ${chalk.italic('--config')} and ${chalk.italic(
-      '--pipeline'
-    )} should be used to process a single pipeline.`
-  );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,26 +13,19 @@ console.info(
 );
 
 async function main(): Promise<void> {
-  let pipelines = new Map<string, LDWorkbenchConfiguration>();
-  pipelines = loadPipelines(
-    cliArgs.config ?? cliArgs.configDir ?? './pipelines/'
-  );
-
-  const names = Array.from(pipelines.keys());
-
-  // this will be the configuration we use:
+  const pipelines = loadPipelines(cliArgs.config ?? './pipelines/');
+  const names = [...pipelines.keys()];
   let configuration: LDWorkbenchConfiguration | undefined;
 
   if (cliArgs.pipeline !== undefined) {
-    const config = pipelines.get(cliArgs.pipeline);
-    if (config === undefined) {
+    configuration = pipelines.get(cliArgs.pipeline);
+    if (configuration === undefined) {
       error(
-        `No pipeline named "${cliArgs.pipeline}" was found.`,
+        `No pipeline named “${cliArgs.pipeline}” was found.`,
         2,
         `Valid pipeline names are: ${names.map(name => `"${name}"`).join(', ')}`
       );
     }
-    configuration = pipelines.get(cliArgs.pipeline);
   } else if (names.length === 1) {
     configuration = pipelines.get(names[0]);
   }
@@ -54,12 +47,6 @@ async function main(): Promise<void> {
       );
     }
     configuration = pipelines.get(answers.pipeline);
-  } else if (names.length !== 1) {
-    error(
-      'This should not happen: no pipeline was picked, but we have multiple.'
-    );
-  } else {
-    configuration = pipelines.get(names[0]);
   }
 
   if (configuration === undefined) {

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -9,7 +9,7 @@ export default function init(): void {
     throw new Error(
       'The --init script found an existing directory "' +
         path.join('pipelines', 'configurations', 'example') +
-        '". Make sure this directory does not exists before running this script.'
+        '". Make sure this directory does not exist before running this script.'
     );
   }
   fs.mkdirSync(path.join('pipelines', 'data'), {recursive: true});


### PR DESCRIPTION
* The distinction between `--config` and `--configDir` is confusing,
  so remove the latter.
* Fix the `--pipeline` argument.

Fix #72
