### PR TITLE
fix: Import progress

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,10 @@ export default {
   coverageReporters: ['json-summary', 'text'],
   coverageThreshold: {
     global: {
-      lines: 70.9,
-      statements: 71.01,
+      lines: 70.65,
+      statements: 70.77,
       branches: 66.66,
-      functions: 76.59,
+      functions: 76.05,
     },
   },
   transform: {

--- a/src/stage.ts
+++ b/src/stage.ts
@@ -23,6 +23,7 @@ interface Events {
   end: [iteratorCount: number, statements: number];
   iteratorResult: [$this: NamedNode, quadsGenerated: number];
   error: [Error];
+  importError: [Error];
 }
 
 export default class Stage extends EventEmitter<Events> {
@@ -105,7 +106,7 @@ export default class Stage extends EventEmitter<Events> {
       try {
         await this.importer.run();
       } catch (e) {
-        this.emit('error', e as Error);
+        this.emit('importError', e as Error);
         return;
       }
     }


### PR DESCRIPTION
Use separate progress (and spinner) for import
to fix interference with the stage’s progress.