### PR TITLE
feat: Handle zero iterator results

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,10 @@ export default {
   coverageReporters: ['json-summary', 'text'],
   coverageThreshold: {
     global: {
-      lines: 70.65,
-      statements: 70.77,
-      branches: 66.66,
-      functions: 76.05,
+      lines: 71.03,
+      statements: 71.14,
+      branches: 67,
+      functions: 76.76,
     },
   },
   transform: {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -118,7 +118,9 @@ export default class Generator extends EventEmitter<Events> {
   }
 
   private async flush(): Promise<void> {
-    await this.runBatch(this.$thisList);
+    if (this.$thisList.length > 0) {
+      await this.runBatch(this.$thisList);
+    }
   }
 }
 

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -37,7 +37,7 @@ export default class Iterator extends EventEmitter<Events> {
       const error = (e: unknown): Error =>
         new Error(
           `The Iterator did not run successfully, it could not get the results from the endpoint ${
-            this.source
+            this.source?.value
           } (offset: ${this.offset}, limit ${this.query.limit}): ${
             (e as Error).message
           }`
@@ -62,6 +62,14 @@ export default class Iterator extends EventEmitter<Events> {
         });
         stream.on('end', () => {
           this.totalResults += resultsPerPage;
+          if (this.totalResults === 0) {
+            this.emit(
+              'error',
+              error(
+                new Error(`no results for query:\n ${this.query.toString()}`)
+              )
+            );
+          }
           this.offset += this.query.limit;
           if (resultsPerPage < this.query.limit!) {
             this.emit('end', this.totalResults);


### PR DESCRIPTION
* Stop pipeline with error if iterator returns no results. 
* Prevent `flush()` from calling the generator with an empty result set,
  which caused an unclear error message about the generator query.