### PR TITLE
feat: Improve error messages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,10 @@ export default {
   coverageReporters: ['json-summary', 'text'],
   coverageThreshold: {
     global: {
-      lines: 71.03,
-      statements: 71.14,
-      branches: 67,
-      functions: 76.76,
+      lines: 71.74,
+      statements: 71.73,
+      branches: 67.17,
+      functions: 80.85,
     },
   },
   transform: {

--- a/src/file.ts
+++ b/src/file.ts
@@ -14,20 +14,20 @@ import {pipeline as streamPipeline} from 'stream/promises';
 import {Progress} from './progress.js';
 
 export default class File {
-  public readonly $id = 'File';
   private $isValid?: boolean;
 
   public constructor(
     private $path: string,
     private readonly skipExistsCheck: boolean = false
-  ) {}
+  ) {
+    this.validate();
+  }
 
-  public validate(): File {
+  private validate(): File {
     if (this.$isValid !== undefined) return this;
     if (!isFilePathString(this.$path)) {
-      const wrongFilePath: string = this.$path as string;
       throw new Error(
-        `The filename \`${wrongFilePath}\` should start with \`file://\``
+        `The filename \`${this.$path}\` should start with \`file://\``
       );
     }
     this.$path = this.$path.replace(/^file:\/\//, '');
@@ -56,7 +56,6 @@ export default class File {
   }
 
   public toString(): string {
-    this.validate();
     return this.$path;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import type {Configuration} from './configuration.js';
 import loadPipelines from './utils/loadPipelines.js';
 import Pipeline from './pipeline.js';
 import {cli} from './cli.js';
+import Process from 'node:process';
 
 console.info(
   chalk.bold(`Welcome to LD Workbench version ${chalk.cyan(version())}`)
@@ -21,8 +22,7 @@ console.info(
     configuration = pipelines.get(cli.pipeline);
     if (configuration === undefined) {
       error(
-        `No pipeline named “${cli.pipeline}” was found.`,
-        `Valid pipeline names are: ${names.map(name => `"${name}"`).join(', ')}`
+        `No pipeline named “${cli.pipeline}” was found. Valid pipeline names are: ${names.map(name => `"${name}"`).join(', ')}`
       );
     }
   } else if (names.length === 1) {
@@ -61,6 +61,7 @@ console.info(
     });
     await pipeline.run();
   } catch (e) {
-    error(`Error in pipeline ${chalk.italic(configuration.name)}`, e as Error);
+    error(e as Error);
+    Process.exit(1);
   }
 })();

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -62,7 +62,7 @@ class Pipeline {
     }
     this.destination = isTriplyDBPathString(destinationFile)
       ? new TriplyDB(destinationFile).validate()
-      : new File(destinationFile, true).validate();
+      : new File(destinationFile, true);
 
     this.stores = (configuration.stores ?? []).map(
       storeConfig =>
@@ -125,9 +125,10 @@ class Pipeline {
         );
       } catch (e) {
         throw new Error(
-          `Error in the iterator of stage \`${stageConfiguration.name}\`: ${
+          `Error in the configuration of stage “${stageConfiguration.name}”: ${
             (e as Error).message
-          }`
+          }`,
+          {cause: e}
         );
       }
     }
@@ -207,7 +208,7 @@ class Pipeline {
         this.increaseProgress(progress, stage, iterationsProcessed, count);
       });
       stage.on('error', e => {
-        progress.fail('Error: ' + (e as Error).message);
+        progress.fail(`Stage “${this.name}” failed`);
         reject(e);
       });
       stage.on('end', (iris, statements) => {

--- a/src/stage.ts
+++ b/src/stage.ts
@@ -75,7 +75,8 @@ export default class Stage extends EventEmitter<Events> {
         );
       }
     }
-    this.destination = () => new File(this.destinationPath).getStream();
+    this.destination = () =>
+      new File(`file://${this.destinationPath}`, true).getStream();
   }
 
   public get destinationPath(): string {
@@ -157,7 +158,6 @@ export default class Stage extends EventEmitter<Events> {
       this.emit('error', e);
     });
 
-    // Start the iterator
     await this.iterator.run();
   }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,11 +1,10 @@
-import chalk from 'chalk';
-
-export const error = (
-  message: string | Error,
-  ...info: Array<string | Error>
-): void => {
-  console.error(
-    chalk.red(message instanceof Error ? message.message : message)
-  );
-  info.forEach(i => console.info(i));
+export const error = (message: string | Error): void => {
+  if (message instanceof Error) {
+    console.error(`\n${message.message}`);
+    if (message.cause) {
+      console.error('\nCaused by:\n', message.cause);
+    }
+  } else {
+    console.error(`\n${message}`);
+  }
 };

--- a/test/file.test.ts
+++ b/test/file.test.ts
@@ -16,7 +16,6 @@ describe('File Class', () => {
       expect(file).to.be.an.instanceOf(File);
       expect(file).to.have.property('$path');
       expect(file).to.have.property('skipExistsCheck');
-      expect(file).to.have.property('$id');
     });
   });
   describe('validate', () => {
@@ -24,31 +23,26 @@ describe('File Class', () => {
       const path = './static/example/config.yml';
       const validFilePath = `file://${path}`;
       const file = new File(validFilePath);
-      expect(file.validate());
       expect(file.path).to.equal(path);
     });
 
     it('should throw an error for an invalid file path', () => {
       const filePath = 'invalid/file/path.txt';
-      const file = new File(filePath);
-      expect(file.validate.bind(file)).to.throw(
+      expect(() => new File(filePath)).to.throw(
         'The filename `invalid/file/path.txt` should start with `file://`'
       );
     });
 
     it('should throw an error if file does not exist', () => {
       const filePath = 'file://nonexistent/file.txt';
-      const file = new File(filePath);
-      expect(file.validate.bind(file)).to.throw(
+      expect(() => new File(filePath)).to.throw(
         'File not found: `nonexistent/file.txt`'
       );
     });
 
     it('should skip exists check when skipExistsCheck is true', () => {
       const filePath = 'file://nonexistent/file.txt';
-      const file = new File(filePath, true);
-      expect(() => file.validate()).to.not.throw();
-      expect(file.path).to.equal('nonexistent/file.txt');
+      expect(new File(filePath, true).path).to.equal('nonexistent/file.txt');
     });
   });
 
@@ -73,15 +67,15 @@ describe('File Class', () => {
       }
     });
     it('should create a write stream for a new file', () => {
-      const filePath = 'new/file.txt';
-      const file = new File(filePath);
+      const filePath = 'file://new/file.txt';
+      const file = new File(filePath, true);
       writeStream = file.getStream();
       expect(writeStream).to.be.an.instanceOf(fs.WriteStream);
       writeStream.end();
     });
 
     it('should append to an existing file when append is true', () => {
-      const filePath = 'file.txt';
+      const filePath = 'file://file.txt';
       const file = new File(filePath);
       writeStream = file.getStream(true);
       expect(writeStream).to.be.an.instanceOf(fs.WriteStream);
@@ -89,7 +83,7 @@ describe('File Class', () => {
 
     it('should create parent directories if they do not exist', async () => {
       const filePath = 'file://new/directory/nested/file.txt';
-      const file = new File(filePath, true).validate();
+      const file = new File(filePath, true);
       writeStream = file.getStream();
       expect(writeStream).to.be.an.instanceOf(fs.WriteStream);
       expect(

--- a/test/iterator.test.ts
+++ b/test/iterator.test.ts
@@ -138,7 +138,7 @@ describe('Iterator Class', () => {
         new File('file://static/tests/iris-small.nt')
       );
       await expect(async () => await runIterator(iterator)).rejects.toThrow(
-        'no results for query:\n SELECT ?this WHERE { ?this <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/no-matches>. }'
+        'No results'
       );
     });
   });

--- a/test/utils/utilities.test.ts
+++ b/test/utils/utilities.test.ts
@@ -307,7 +307,6 @@ describe('Utilities', () => {
   });
   describe('getEndpoint', () => {
     it('should return File when filePath is provided in Stage', () => {
-      const filePath = 'file://path/to/file.txt';
       const config: Configuration = {
         name: 'Example Pipeline',
         description:
@@ -318,7 +317,7 @@ describe('Utilities', () => {
             name: 'Stage 1',
             iterator: {
               query: 'file://static/example/iterator-stage-1.rq',
-              endpoint: filePath,
+              endpoint: 'file://static/tests/iris.nt',
             },
             generator: [
               {
@@ -334,7 +333,7 @@ describe('Utilities', () => {
       const retrievedEndpoint = getEndpoint(stage);
       expect(
         isFile(retrievedEndpoint) &&
-          retrievedEndpoint.path === 'file://path/to/file.txt'
+          retrievedEndpoint.path === 'static/tests/iris.nt'
       ).to.equal(true);
     });
     it('should return URL when URL is provided in Stage', () => {
@@ -391,7 +390,7 @@ describe('Utilities', () => {
         ],
       };
       expect(() => new Pipeline(config, {silent: true})).to.throw(
-        'Error in the iterator of stage `Stage 1`: "invalidExample" is not a valid URL'
+        'Error in the configuration of stage “Stage 1”: "invalidExample" is not a valid URL'
       );
     });
     it('should throw if stage has undefined endpoint and is first stage', () => {
@@ -467,7 +466,7 @@ describe('Utilities', () => {
       expect(result instanceof QueryEngineSparql).to.equal(true);
     });
     it('should return QueryEngineFile when input is File', () => {
-      const file = new File('file://exampleFile.txt');
+      const file = new File('file://exampleFile.txt', true);
       const result = getEngine(file);
       expect(result instanceof QueryEngineFile).to.equal(true);
     });
@@ -523,52 +522,6 @@ describe('Utilities', () => {
         type: 'sparql',
         value: url.toString(),
       });
-    });
-    it('should return engine source string when input is PreviousStage with destinationPath', async () => {
-      const config: Configuration = {
-        name: 'Example Pipeline',
-        description:
-          'This is an example pipeline. It uses files that are available in this repository  and SPARQL endpoints that should work.\n',
-        destination: 'file://pipelines/data/example-pipeline.nt',
-        stages: [
-          {
-            name: 'Stage 1',
-            iterator: {
-              query: 'file://static/example/iterator-stage-1.rq',
-              endpoint: 'file://static/tests/iris.nt',
-            },
-            generator: [
-              {
-                query: 'file://static/example/generator-stage-1-1.rq',
-              },
-            ],
-          },
-          {
-            name: 'Stage 2',
-            iterator: {
-              query: 'file://static/example/iterator-stage-2.rq',
-            },
-            generator: [
-              {
-                query: 'file://static/example/generator-stage-2.rq',
-                endpoint: 'file://static/tests/wikidata.nt',
-              },
-            ],
-          },
-        ],
-      };
-      const pipeline = new Pipeline(config, {silent: true});
-      const stage2: Stage = new Stage(pipeline, config.stages[1]);
-      const stagesSoFar = Array.from(stage2.pipeline.stages.keys());
-      const previousStage = new PreviousStage(stage2, stagesSoFar.pop()!);
-      const engineSource = getEngineSource(previousStage);
-      expect(
-        engineSource.value ===
-          path.join(
-            process.cwd(),
-            '/pipelines/data/example-pipeline/stage-1.nt'
-          )
-      ).to.equal(true);
     });
     describe('should throw', () => {
       beforeEach(() => {


### PR DESCRIPTION
* Validate File on construction to prevent invalid object state.
* Fix errors printed twice.
* Move error message construction to dedicated error objects.
* Improve error message clarity. Keep error’s cause for a full stack trace,
  but don’t throw to improve legibility.